### PR TITLE
Simplify ApiError messages and add data attributes

### DIFF
--- a/webexteamssdk/exceptions.py
+++ b/webexteamssdk/exceptions.py
@@ -53,7 +53,10 @@ class AccessTokenError(webexteamssdkException):
 
 
 class ApiError(webexteamssdkException):
-    """Errors returned by requests to the Webex Teams cloud APIs."""
+    """Errors returned in response to requests sent to the Webex Teams APIs.
+
+    Several data attributes are available for inspection.
+    """
 
     def __init__(self, response):
         assert isinstance(response, requests.Response)

--- a/webexteamssdk/exceptions.py
+++ b/webexteamssdk/exceptions.py
@@ -29,99 +29,17 @@ from __future__ import (
     print_function,
     unicode_literals,
 )
-from builtins import *
 
 import logging
-import sys
-import textwrap
+from builtins import *
 from json import JSONDecodeError
 
 import requests
-from past.builtins import basestring
 
 from .response_codes import RESPONSE_CODES
 
 
 logger = logging.getLogger(__name__)
-
-
-def _to_unicode(string):
-    """Convert a string (bytes, str or unicode) to unicode."""
-    assert isinstance(string, basestring)
-    if sys.version_info[0] >= 3:
-        if isinstance(string, bytes):
-            return string.decode('utf-8')
-        else:
-            return string
-    else:
-        if isinstance(string, str):
-            return string.decode('utf-8')
-        else:
-            return string
-
-
-def _sanitize(header_tuple):
-    """Sanitize request headers.
-
-    Remove authentication `Bearer` token.
-    """
-    header, value = header_tuple
-
-    if (header.lower().strip() == "Authorization".lower().strip()
-            and "Bearer".lower().strip() in value.lower().strip()):
-        return header, "Bearer <redacted>"
-
-    else:
-        return header_tuple
-
-
-def _response_to_string(response):
-    """Render a response object as a human readable string."""
-    assert isinstance(response, requests.Response)
-    request = response.request
-
-    section_header = "{title:-^79}"
-
-    # Prepare request components
-    req = textwrap.fill("{} {}".format(request.method, request.url),
-                        width=79,
-                        subsequent_indent=' ' * (len(request.method) + 1))
-    req_headers = [
-        textwrap.fill("{}: {}".format(*_sanitize(header)),
-                      width=79,
-                      subsequent_indent=' ' * 4)
-        for header in request.headers.items()
-    ]
-    req_body = (textwrap.fill(_to_unicode(request.body), width=79)
-                if request.body else "")
-
-    # Prepare response components
-    resp = textwrap.fill("{} {}".format(response.status_code,
-                                        response.reason
-                                        if response.reason else ""),
-                         width=79,
-                         subsequent_indent=' ' * (len(request.method) + 1))
-    resp_headers = [
-        textwrap.fill("{}: {}".format(*header), width=79,
-                      subsequent_indent=' ' * 4)
-        for header in response.headers.items()
-    ]
-    resp_body = textwrap.fill(response.text, width=79) if response.text else ""
-
-    # Return the combined string
-    return "\n".join([
-        section_header.format(title="Request"),
-        req,
-        "\n".join(req_headers),
-        "",
-        req_body,
-        "",
-        section_header.format(title="Response"),
-        resp,
-        "\n".join(resp_headers),
-        "",
-        resp_body,
-    ])
 
 
 class webexteamssdkException(Exception):

--- a/webexteamssdk/response_codes.py
+++ b/webexteamssdk/response_codes.py
@@ -32,10 +32,9 @@ from __future__ import (
 
 
 RESPONSE_CODES = {
-    200: "OK",
-    204: "Member deleted.",
-    400: "The request was invalid or cannot be otherwise served. An "
-         "accompanying error message will explain further.",
+    200: "Successful request with body content.",
+    204: "Successful request without body content.",
+    400: "The request was invalid or cannot be otherwise served.",
     401: "Authentication credentials were missing or incorrect.",
     403: "The request is understood, but it has been refused or access is not "
          "allowed.",
@@ -47,11 +46,15 @@ RESPONSE_CODES = {
     409: "The request could not be processed because it conflicts with some "
          "established rule of the system. For example, a person may not be "
          "added to a room more than once.",
+    415: "The request was made to a resource without specifying a media type "
+         "or used a media type that is not supported.",
     429: "Too many requests have been sent in a given amount of time and the "
          "request has been rate limited. A Retry-After header should be "
          "present that specifies how many seconds you need to wait before a "
          "successful request can be made.",
-    500: "Something went wrong on the server.",
+    500: "Something went wrong on the server. If the issue persists, feel "
+         "free to contact the Webex Developer Support team "
+         "(https://developer.webex.com/support).",
     502: "The server received an invalid response from an upstream server "
          "while processing the request. Try again later.",
     503: "Server is overloaded with requests. Try again later."


### PR DESCRIPTION
Per issue #62: Simplify the default string interpretation of the `ApiError` messages.

The simplified messages will use the `message` attribute of the returned JSON (if present) to provide more insight as to why the request failed and will default to the generic error descriptions from the API docs if a `message` attribute is not available.

**Example of the New Message Format:**

```python
ApiError: [400] Bad Request - Message destination could not be determined. Provide only one destination in the roomId, toPersonEmail, or toPersonId field
```

The `ApiError` exceptions now have several attributes exposed for inspection:

- `response` - The `requests.Response` object returned from the API call.
- `request` - The `requests.PreparedRequest` used to submit the API request.
-  `status_code` - The HTTP status code from the API response.
- `status` - The HTTP status from the API response.
- `details` - The parsed JSON details from the API response.
- `message` - The error message from the parsed API response.
- `description` - A description of the HTTP Response Code from the API docs.

This enhancement also solves issue #68.