### PR TITLE
Added ability to retrieve API tokens for guest issuers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ INSTALLATION_REQUIREMENTS = [
     'future',
     'requests>=2.4.2',
     'requests-toolbelt',
+    'PyJWT'
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,11 +76,11 @@ def temp_directory():
 
 @pytest.fixture("session")
 def local_file(temp_directory):
-        file = download_file(WEBEX_TEAMS_TEST_FILE_URL, temp_directory)
+    file = download_file(WEBEX_TEAMS_TEST_FILE_URL, temp_directory)
 
-        yield file
+    yield file
 
-        os.remove(file)
+    os.remove(file)
 
 
 @pytest.fixture(scope="session")

--- a/webexteamssdk/api/__init__.py
+++ b/webexteamssdk/api/__init__.py
@@ -45,6 +45,7 @@ from .rooms import RoomsAPI
 from .team_memberships import TeamMembershipsAPI
 from .teams import TeamsAPI
 from .webhooks import WebhooksAPI
+from .guest_issuer import GuestIssuerAPI
 
 
 class WebexTeamsAPI(object):
@@ -143,6 +144,7 @@ class WebexTeamsAPI(object):
             single_request_timeout=single_request_timeout
         )
         self.events = EventsAPI(self._session, object_factory)
+        self.guest_issuer = GuestIssuerAPI(self._session, object_factory)
 
     @property
     def access_token(self):

--- a/webexteamssdk/api/guest_issuer.py
+++ b/webexteamssdk/api/guest_issuer.py
@@ -95,6 +95,11 @@ class GuestIssuerAPI(object):
             TypeError: If the parameter types are incorrect
             ApiError: If the webex teams cloud returns an error.
         """
+        check_type(subject, basestring)
+        check_type(displayName, basestring)
+        check_type(issuerToken, basestring)
+        check_type(expiration, basestring)
+        check_type(secret, basestring)
 
         payload = {
             "sub": subject,

--- a/webexteamssdk/api/guest_issuer.py
+++ b/webexteamssdk/api/guest_issuer.py
@@ -50,6 +50,7 @@ import requests
 API_ENDPOINT = 'jwt'
 OBJECT_TYPE = 'guest_issuer_token'
 
+
 class GuestIssuerAPI(object):
     """Webex Teams Guest Issuer API.
 
@@ -94,7 +95,6 @@ class GuestIssuerAPI(object):
             TypeError: If the parameter types are incorrect
             ApiError: If the webex teams cloud returns an error.
         """
-        #ToDo(mneiding): Check types
 
         payload = {
             "sub": subject,

--- a/webexteamssdk/api/guest_issuer.py
+++ b/webexteamssdk/api/guest_issuer.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Webex Teams Guest Issuer API wrapper.
+
+Copyright (c) 2016-2018 Cisco and/or its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
+from builtins import *
+
+from past.builtins import basestring
+
+from ..generator_containers import generator_container
+from ..restsession import RestSession
+from ..utils import (
+    check_type,
+    dict_from_items_with_values,
+    check_response_code
+)
+from ..response_codes import EXPECTED_RESPONSE_CODE
+
+
+import jwt
+import base64
+import requests
+
+API_ENDPOINT = 'jwt'
+OBJECT_TYPE = 'guest_issuer_token'
+
+class GuestIssuerAPI(object):
+    """Webex Teams Guest Issuer API.
+
+    Wraps the Webex Teams Guest Issuer API and exposes the API as native
+    methods that return native Python objects.
+
+    """
+
+    def __init__(self, session, object_factory):
+        """Initialize a new GuestIssuerAPI object with the provided RestSession
+
+        Args:
+            session(RestSession): The RESTful session object to be used for
+            API calls to the Webex Teams service
+
+        Raises:
+            TypeError: If the parameter types are incorrect
+        """
+        check_type(session, RestSession)
+
+        super(GuestIssuerAPI, self).__init__()
+
+        self._session = session
+        self._object_factory = object_factory
+
+    def create(self, subject, displayName, issuerToken, expiration, secret):
+        """Create a new guest issuer using the provided issuer token.
+
+        This function returns a guest issuer with an api access token.
+
+        Args:
+            subject(basestring): Unique and public identifier
+            displayName(basestring): Display Name of the guest user
+            issuerToken(basestring): Issuer token from developer hub
+            expiration(basestring): Expiration time as a unix timestamp
+            secret(basestring): The secret used to sign your guest issuers
+
+        Returns:
+            GuestIssuerToken: A Guest Issuer with a valid access token.
+
+        Raises:
+            TypeError: If the parameter types are incorrect
+            ApiError: If the webex teams cloud returns an error.
+        """
+        #ToDo(mneiding): Check types
+
+        payload = {
+            "sub": subject,
+            "name": displayName,
+            "iss": issuerToken,
+            "exp": expiration
+        }
+
+        key = base64.b64decode(secret)
+        jwt_token = jwt.encode(payload, key, algorithm='HS256')
+
+        url = self._session.base_url + API_ENDPOINT + "/" + "login"
+        headers = {
+            'Authorization': "Bearer " + jwt_token.decode('utf-8')
+        }
+        response = requests.post(url, headers=headers)
+        check_response_code(response, EXPECTED_RESPONSE_CODE['GET'])
+
+        return self._object_factory(OBJECT_TYPE, response.json())

--- a/webexteamssdk/models/immutable.py
+++ b/webexteamssdk/models/immutable.py
@@ -54,6 +54,7 @@ from .mixins.team import TeamBasicPropertiesMixin
 from .mixins.team_membership import TeamMembershipBasicPropertiesMixin
 from .mixins.webhook import WebhookBasicPropertiesMixin
 from .mixins.webhook_event import WebhookEventBasicPropertiesMixin
+from .mixins.guest_issuer_token import GuestIssuerTokenBasicPropertiesMixin
 
 
 class ImmutableData(object):
@@ -228,6 +229,9 @@ class WebhookEvent(ImmutableData, WebhookEventBasicPropertiesMixin):
         """The event resource data."""
         return ImmutableData(self._json_data.get('data'))
 
+class GuestIssuerToken(ImmutableData, GuestIssuerTokenBasicPropertiesMixin):
+    """Webex Teams Guest Issuer Token data model"""
+
 
 immutable_data_models = defaultdict(
     lambda: ImmutableData,
@@ -244,6 +248,7 @@ immutable_data_models = defaultdict(
     team_membership=TeamMembership,
     webhook=Webhook,
     webhook_event=WebhookEvent,
+    guest_issuer_token=GuestIssuerToken,
 )
 
 

--- a/webexteamssdk/models/immutable.py
+++ b/webexteamssdk/models/immutable.py
@@ -229,6 +229,7 @@ class WebhookEvent(ImmutableData, WebhookEventBasicPropertiesMixin):
         """The event resource data."""
         return ImmutableData(self._json_data.get('data'))
 
+
 class GuestIssuerToken(ImmutableData, GuestIssuerTokenBasicPropertiesMixin):
     """Webex Teams Guest Issuer Token data model"""
 

--- a/webexteamssdk/models/mixins/guest_issuer_token.py
+++ b/webexteamssdk/models/mixins/guest_issuer_token.py
@@ -31,6 +31,7 @@ from __future__ import (
 
 from builtins import *
 
+
 class GuestIssuerTokenBasicPropertiesMixin(object):
     """Guest issuer token basic properties"""
 

--- a/webexteamssdk/models/mixins/guest_issuer_token.py
+++ b/webexteamssdk/models/mixins/guest_issuer_token.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Webex Teams Guest-Issuer data model.
+
+Copyright (c) 2016-2018 Cisco and/or its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
+from builtins import *
+
+class GuestIssuerTokenBasicPropertiesMixin(object):
+    """Guest issuer token basic properties"""
+
+    @property
+    def access_token(self):
+        return self._json_data.get('token')
+
+    @property
+    def expires_in(self):
+        return self._json_data.get('expiresIn')


### PR DESCRIPTION
This PR adds the ability to obtain the API access tokens for [guest issuer](https://developer.webex.com/docs/guest-issuer) within the Webex Teams API. 

Usage:
```python3
from webexteamssdk import WebexTeamsAPI

api = WebexTeamsAPI()
ISSUER_ID = "<issuer_id_from_developer_portal>"
ISSUER_SECRET = "<issuer_secret_from_developer_portal>"
gi = api.guest_issuer.create(subject="guest-issuer-1",
                            displayName="Guest Issuer No. 2",
                            issuerToken=ISSUER_ID,
                            expiration="1577145600",
                            secret=ISSUER_SECRET
                            )

print("Token: {}".format(gi.access_token))

gi_api = WebexTeamsAPI(access_token=gi.access_token)
gi_api.messages.create(toPersonEmail="mneiding@cisco.com", markdown="**Test from your new guest issuer**")

```