### PR TITLE
Initialize API with OAuth Credentials

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,11 +76,11 @@ def temp_directory():
 
 @pytest.fixture("session")
 def local_file(temp_directory):
-        file = download_file(WEBEX_TEAMS_TEST_FILE_URL, temp_directory)
+    file = download_file(WEBEX_TEAMS_TEST_FILE_URL, temp_directory)
 
-        yield file
+    yield file
 
-        os.remove(file)
+    os.remove(file)
 
 
 @pytest.fixture(scope="session")

--- a/webexteamssdk/api/__init__.py
+++ b/webexteamssdk/api/__init__.py
@@ -47,7 +47,6 @@ from .teams import TeamsAPI
 from .webhooks import WebhooksAPI
 
 
-
 class WebexTeamsAPI(object):
     """Webex Teams API wrapper.
 
@@ -70,7 +69,8 @@ class WebexTeamsAPI(object):
         """Create a new WebexTeamsAPI object.
 
         An access token must be used when interacting with the Webex Teams API.
-        This package supports thre methods for you to provide that access token:
+        This package supports three methods for you to provide that access
+        token:
 
           1. You may manually specify the access token via the `access_token`
              argument, when creating a new WebexTeamsAPI object.
@@ -103,8 +103,8 @@ class WebexTeamsAPI(object):
                 upon creation in the portal.
             client_secret(basestring): The client secret of your integration.
                 Provided upon creation in the portal.
-            oauth_code(basestring): The oauth authorization code provided by the
-                user oauth process.
+            oauth_code(basestring): The oauth authorization code provided by
+                the user oauth process.
             oauth_redirect_uri(basestring): The redirect URI used in the user
                 OAuth process.
 
@@ -134,7 +134,7 @@ class WebexTeamsAPI(object):
         self.access_tokens = AccessTokensAPI(
             self.base_url, object_factory,
             single_request_timeout=single_request_timeout
-            )
+        )
         if not access_token and check_all_not_none(oauth_param_list):
             access_token = self.access_tokens.get(client_id=client_id,
                                                   client_secret=client_secret,

--- a/webexteamssdk/utils.py
+++ b/webexteamssdk/utils.py
@@ -127,6 +127,7 @@ def open_local_file(file_path):
                          file_object=file_object,
                          content_type=content_type)
 
+
 def check_all_not_none(l):
     """Checks if all the elements in the list are not none.
 
@@ -142,6 +143,8 @@ def check_all_not_none(l):
             return false
 
     return true
+
+
 def check_type(o, acceptable_types, may_be_none=True):
     """Object is an instance of one of the acceptable types or None.
 

--- a/webexteamssdk/utils.py
+++ b/webexteamssdk/utils.py
@@ -140,9 +140,9 @@ def check_all_not_none(l):
     """
     for o in l:
         if o is None:
-            return false
+            return False
 
-    return true
+    return True
 
 
 def check_type(o, acceptable_types, may_be_none=True):

--- a/webexteamssdk/utils.py
+++ b/webexteamssdk/utils.py
@@ -127,7 +127,21 @@ def open_local_file(file_path):
                          file_object=file_object,
                          content_type=content_type)
 
+def check_all_not_none(l):
+    """Checks if all the elements in the list are not none.
 
+    Args:
+        l(list): A list of objects that should be checked
+
+    Returns:
+        boolean: True if all list items are not none, false otherwise
+
+    """
+    for o in l:
+        if o is None:
+            return false
+
+    return true
 def check_type(o, acceptable_types, may_be_none=True):
     """Object is an instance of one of the acceptable types or None.
 


### PR DESCRIPTION
This PR introduces the ability to initialize the API by providing the credentials obtained by an OAuth flow (issue #61).