### PR TITLE
Added proxy feature

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -150,6 +150,14 @@ directly by providing the OAuth information.
                             redirect_uri=redirect_uri
                            )
 
+You can also pass a proxy configuration upon initialization in case you are behind a firewall. 
+
+.. code-block:: python
+    >>> from webexteamssdk import WebexTeamsAPI
+    >>> proxy = {'https': '<proxy_ip>:<proxy_port>'}
+    >>> api = WebexTeamsAPI(access_token=<your_access_token>, proxy_dict=proxy)
+
+
 Making API Calls
 ----------------
 

--- a/webexteamssdk/api/__init__.py
+++ b/webexteamssdk/api/__init__.py
@@ -66,7 +66,8 @@ class WebexTeamsAPI(object):
                  client_id=None,
                  client_secret=None,
                  oauth_code=None,
-                 redirect_uri=None):
+                 redirect_uri=None,
+                 proxy_dict=None):
         """Create a new WebexTeamsAPI object.
 
         An access token must be used when interacting with the Webex Teams API.
@@ -108,6 +109,8 @@ class WebexTeamsAPI(object):
                 the user oauth process.
             oauth_redirect_uri(basestring): The redirect URI used in the user
                 OAuth process.
+            proxy_dict(dict): Dictionary of proxies passed on to the requests 
+                session.
 
         Returns:
             WebexTeamsAPI: A new WebexTeamsAPI object.
@@ -126,6 +129,7 @@ class WebexTeamsAPI(object):
         check_type(client_secret, basestring, may_be_none=True)
         check_type(oauth_code, basestring, may_be_none=True)
         check_type(redirect_uri, basestring, may_be_none=True)
+        check_type(proxy_dict, dict, may_be_none=True)
 
         access_token = access_token or WEBEX_TEAMS_ACCESS_TOKEN
 
@@ -162,7 +166,8 @@ class WebexTeamsAPI(object):
             access_token=access_token,
             base_url=base_url,
             single_request_timeout=single_request_timeout,
-            wait_on_rate_limit=wait_on_rate_limit
+            wait_on_rate_limit=wait_on_rate_limit, 
+            proxy_dict=proxy_dict
         )
 
         # API wrappers

--- a/webexteamssdk/restsession.py
+++ b/webexteamssdk/restsession.py
@@ -99,7 +99,8 @@ class RestSession(object):
 
     def __init__(self, access_token, base_url,
                  single_request_timeout=DEFAULT_SINGLE_REQUEST_TIMEOUT,
-                 wait_on_rate_limit=DEFAULT_WAIT_ON_RATE_LIMIT):
+                 wait_on_rate_limit=DEFAULT_WAIT_ON_RATE_LIMIT,
+                 proxy_dict=None):
         """Initialize a new RestSession object.
 
         Args:
@@ -111,6 +112,8 @@ class RestSession(object):
                 HTTP REST API request.
             wait_on_rate_limit(bool): Enable or disable automatic rate-limit
                 handling.
+            proxy_dict(dict): Dictionary of proxies passed on to the requests 
+                session.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -120,6 +123,7 @@ class RestSession(object):
         check_type(base_url, basestring, may_be_none=False)
         check_type(single_request_timeout, int)
         check_type(wait_on_rate_limit, bool, may_be_none=False)
+        check_type(proxy_dict, dict, may_be_none=True)
 
         super(RestSession, self).__init__()
 
@@ -131,6 +135,9 @@ class RestSession(object):
 
         # Initialize a new `requests` session
         self._req_session = requests.session()
+
+        if proxy_dict is not None:
+            self._req_session.proxies.update(proxy_dict)
 
         # Update the headers of the `requests` session
         self.update_headers({'Authorization': 'Bearer ' + access_token,


### PR DESCRIPTION
This PR allows the user to specify a web proxy to use with the outgoing session. 

User can specify the proxy upon creation of the api object. 

```python
from webexteamssdk import WebexTeamsAPI
proxy = {'https': '<proxy_ip>:<proxy_port>'}
api = WebexTeamsAPI(access_token=<your_access_token>, proxy_dict=proxy)
```