### PR TITLE
Fixed error not being able to get inputs property from attachment actions

### DIFF
--- a/webexteamssdk/models/mixins/attachment_action.py
+++ b/webexteamssdk/models/mixins/attachment_action.py
@@ -70,7 +70,7 @@ class AttachmentActionBasicPropertiesMixin(object):
     @property
     def inputs(self):
         """The action's inputs."""
-        return self._json_data('inputs')
+        return self._json_data.get('inputs')
 
     @property
     def created(self):


### PR DESCRIPTION
When accessing the `.inputs` property the current version errors with a `OrderedDict is not callable error`. 

This PR fixes the error by adding the `_json_data.get('inputs')` call in the property. 

As a workaround one can access the property directly:

```python
attachment = api.attachment_actions.get(attachment_id)
inputs = attachment._json_data.get('inputs')
```