### PR TITLE
Fixed simple property rendering (fixes CiscoDevNet/webexteamssdk#107)

### DIFF
--- a/webexteamssdk/models/cards/actions.py
+++ b/webexteamssdk/models/cards/actions.py
@@ -49,8 +49,8 @@ class Submit(AdaptiveCardComponent):
         self.iconURL = iconURL
 
         super().__init__(
-            serializable_properties=['data'],
-            simple_properties=['title', 'iconURL', 'type'],
+            serializable_properties=[],
+            simple_properties=['data', 'title', 'iconURL', 'type'],
         )
 
 

--- a/webexteamssdk/models/cards/adaptive_card_component.py
+++ b/webexteamssdk/models/cards/adaptive_card_component.py
@@ -23,7 +23,7 @@ SOFTWARE.
 """
 
 import json
-
+import enum
 
 class AdaptiveCardComponent:
     """Base class for all Adaptive Card components.
@@ -63,7 +63,10 @@ class AdaptiveCardComponent:
             property_value = getattr(self, property_name, None)
 
             if property_value is not None:
-                serialized_data[property_name] = str(property_value)
+                if isinstance(property_value, enum.Enum):
+                    property_value = str(property_value)
+                
+                serialized_data[property_name] = property_value
 
         # Recursively serialize sub-components
         for property_name in self.serializable_properties:


### PR DESCRIPTION
Simple properties are no longer forced into a string representation
and thus retain their original data type (i.e. booleans or numbers).
Only exception are all option enums that are converted into their
string representation.