### PR TITLE
PR to add room meeting details endpoint 

### DIFF
--- a/docs/user/api.rst
+++ b/docs/user/api.rst
@@ -118,6 +118,12 @@ rooms
 
 .. autoclass:: webexteamssdk.api.rooms.RoomsAPI()
 
+.. _room_meeting_details:
+
+room_meeting_details
+--------------------
+
+.. autoclass:: webexteamssdk.api.room_meeting_details.RoomMeetingDetailsAPI()
 
 .. _teams:
 

--- a/docs/user/api_structure_table.rst
+++ b/docs/user/api_structure_table.rst
@@ -1,64 +1,66 @@
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-| :class:`WebexTeamsAPI` | :ref:`access_tokens`      | :meth:`get() <webeteamssdk.api.access_tokens.AccessTokensAPI.get>`              |
-|                        |                           | :meth:`refresh() <webeteamssdk.api.access_tokens.AccessTokensAPI.refresh>`      |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`admin_audit_events` | :meth:`list() <webexteamssdk.api.admin_audit_events.list>`                      |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`attachment_actions` | :meth:`create() <webexteamssdk.api.attachment_actions.create>`                  |
-|                        |                           | :meth:`get() <webexteamssdk.api.attachment_actions.get>`                        |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`events`             | :meth:`list() <webeteamssdk.api.events.EventsAPI.list>`                         |
-|                        |                           | :meth:`get() <webeteamssdk.api.events.EventsAPI.get>`                           |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`guest_issuer`       | :meth:`create() <webexteamssdk.api.guest_issuer.create>`                        |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`licenses`           | :meth:`list() <webeteamssdk.api.licenses.LicensesAPI.list>`                     |
-|                        |                           | :meth:`create() <webeteamssdk.api.licenses.LicensesAPI.create>`                 |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`memberships`        | :meth:`list() <webeteamssdk.api.memberships.MembershipsAPI.list>`               |
-|                        |                           | :meth:`create() <webeteamssdk.api.memberships.MembershipsAPI.create>`           |
-|                        |                           | :meth:`get() <webeteamssdk.api.memberships.MembershipsAPI.get>`                 |
-|                        |                           | :meth:`update() <webeteamssdk.api.memberships.MembershipsAPI.update>`           |
-|                        |                           | :meth:`delete() <webeteamssdk.api.memberships.MembershipsAPI.delete>`           |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`messages`           | :meth:`list() <webeteamssdk.api.messages.MessagesAPI.list>`                     |
-|                        |                           | :meth:`create() <webeteamssdk.api.messages.MessagesAPI.create>`                 |
-|                        |                           | :meth:`get() <webeteamssdk.api.messages.MessagesAPI.get>`                       |
-|                        |                           | :meth:`delete() <webeteamssdk.api.messages.MessagesAPI.delete>`                 |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`organizations`      | :meth:`list() <webeteamssdk.api.organizations.OrganizationsAPI.list>`           |
-|                        |                           | :meth:`create() <webeteamssdk.api.organizations.OrganizationsAPI.create>`       |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`people`             | :meth:`list() <webexteamssdk.api.people.PeopleAPI.list>`                        |
-|                        |                           | :meth:`create() <webexteamssdk.api.people.PeopleAPI.create>`                    |
-|                        |                           | :meth:`get() <webexteamssdk.api.people.PeopleAPI.get>`                          |
-|                        |                           | :meth:`update() <webexteamssdk.api.people.PeopleAPI.update>`                    |
-|                        |                           | :meth:`me() <webexteamssdk.api.people.PeopleAPI.me>`                            |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`roles`              | :meth:`list() <webeteamssdk.api.roles.RolesAPI.list>`                           |
-|                        |                           | :meth:`create() <webeteamssdk.api.roles.RolesAPI.create>`                       |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`rooms`              | :meth:`list() <webeteamssdk.api.rooms.RoomsAPI.list>`                           |
-|                        |                           | :meth:`create() <webeteamssdk.api.rooms.RoomsAPI.create>`                       |
-|                        |                           | :meth:`get() <webeteamssdk.api.rooms.RoomsAPI.get>`                             |
-|                        |                           | :meth:`update() <webeteamssdk.api.rooms.RoomsAPI.update>`                       |
-|                        |                           | :meth:`delete() <webeteamssdk.api.rooms.RoomsAPI.delete>`                       |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`team_memberships`   | :meth:`list() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.list>`      |
-|                        |                           | :meth:`create() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.create>`  |
-|                        |                           | :meth:`get() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.get>`        |
-|                        |                           | :meth:`update() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.update>`  |
-|                        |                           | :meth:`delete() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.delete>`  |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`teams`              | :meth:`list() <webeteamssdk.api.teams.TeamsAPI.list>`                           |
-|                        |                           | :meth:`create() <webeteamssdk.api.teams.TeamsAPI.create>`                       |
-|                        |                           | :meth:`get() <webeteamssdk.api.teams.TeamsAPI.get>`                             |
-|                        |                           | :meth:`update() <webeteamssdk.api.teams.TeamsAPI.update>`                       |
-|                        |                           | :meth:`delete() <webeteamssdk.api.teams.TeamsAPI.delete>`                       |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
-|                        | :ref:`webhooks`           | :meth:`list() <webeteamssdk.api.webhooks.WebhooksAPI.list>`                     |
-|                        |                           | :meth:`create() <webeteamssdk.api.webhooks.WebhooksAPI.create>`                 |
-|                        |                           | :meth:`get() <webeteamssdk.api..WebhooksAPI.get>`                               |
-|                        |                           | :meth:`update() <webeteamssdk.api.webhooks.WebhooksAPI.update>`                 |
-|                        |                           | :meth:`delete() <webeteamssdk.api.webhooks.WebhooksAPI.delete>`                 |
-+------------------------+---------------------------+---------------------------------------------------------------------------------+
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+| :class:`WebexTeamsAPI` | :ref:`access_tokens`        | :meth:`get() <webeteamssdk.api.access_tokens.AccessTokensAPI.get>`              |
+|                        |                             | :meth:`refresh() <webeteamssdk.api.access_tokens.AccessTokensAPI.refresh>`      |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`admin_audit_events`   | :meth:`list() <webexteamssdk.api.admin_audit_events.list>`                      |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`attachment_actions`   | :meth:`create() <webexteamssdk.api.attachment_actions.create>`                  |
+|                        |                             | :meth:`get() <webexteamssdk.api.attachment_actions.get>`                        |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`events`               | :meth:`list() <webeteamssdk.api.events.EventsAPI.list>`                         |
+|                        |                             | :meth:`get() <webeteamssdk.api.events.EventsAPI.get>`                           |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`guest_issuer`         | :meth:`create() <webexteamssdk.api.guest_issuer.create>`                        |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`licenses`             | :meth:`list() <webeteamssdk.api.licenses.LicensesAPI.list>`                     |
+|                        |                             | :meth:`create() <webeteamssdk.api.licenses.LicensesAPI.create>`                 |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`memberships`          | :meth:`list() <webeteamssdk.api.memberships.MembershipsAPI.list>`               |
+|                        |                             | :meth:`create() <webeteamssdk.api.memberships.MembershipsAPI.create>`           |
+|                        |                             | :meth:`get() <webeteamssdk.api.memberships.MembershipsAPI.get>`                 |
+|                        |                             | :meth:`update() <webeteamssdk.api.memberships.MembershipsAPI.update>`           |
+|                        |                             | :meth:`delete() <webeteamssdk.api.memberships.MembershipsAPI.delete>`           |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`messages`             | :meth:`list() <webeteamssdk.api.messages.MessagesAPI.list>`                     |
+|                        |                             | :meth:`create() <webeteamssdk.api.messages.MessagesAPI.create>`                 |
+|                        |                             | :meth:`get() <webeteamssdk.api.messages.MessagesAPI.get>`                       |
+|                        |                             | :meth:`delete() <webeteamssdk.api.messages.MessagesAPI.delete>`                 |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`organizations`        | :meth:`list() <webeteamssdk.api.organizations.OrganizationsAPI.list>`           |
+|                        |                             | :meth:`create() <webeteamssdk.api.organizations.OrganizationsAPI.create>`       |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`people`               | :meth:`list() <webexteamssdk.api.people.PeopleAPI.list>`                        |
+|                        |                             | :meth:`create() <webexteamssdk.api.people.PeopleAPI.create>`                    |
+|                        |                             | :meth:`get() <webexteamssdk.api.people.PeopleAPI.get>`                          |
+|                        |                             | :meth:`update() <webexteamssdk.api.people.PeopleAPI.update>`                    |
+|                        |                             | :meth:`me() <webexteamssdk.api.people.PeopleAPI.me>`                            |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`roles`                | :meth:`list() <webeteamssdk.api.roles.RolesAPI.list>`                           |
+|                        |                             | :meth:`create() <webeteamssdk.api.roles.RolesAPI.create>`                       |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`rooms`                | :meth:`list() <webeteamssdk.api.rooms.RoomsAPI.list>`                           |
+|                        |                             | :meth:`create() <webeteamssdk.api.rooms.RoomsAPI.create>`                       |
+|                        |                             | :meth:`get() <webeteamssdk.api.rooms.RoomsAPI.get>`                             |
+|                        |                             | :meth:`update() <webeteamssdk.api.rooms.RoomsAPI.update>`                       |
+|                        |                             | :meth:`delete() <webeteamssdk.api.rooms.RoomsAPI.delete>`                       |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`room_meeting_details` | :meth:`get() <webexteamssdk.api.room_meeting_details.RoomMeetingDetailsAPI.get>`|
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`team_memberships`     | :meth:`list() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.list>`      |
+|                        |                             | :meth:`create() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.create>`  |
+|                        |                             | :meth:`get() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.get>`        |
+|                        |                             | :meth:`update() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.update>`  |
+|                        |                             | :meth:`delete() <webeteamssdk.api.team_memberships.TeamMembershipsAPI.delete>`  |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`teams`                | :meth:`list() <webeteamssdk.api.teams.TeamsAPI.list>`                           |
+|                        |                             | :meth:`create() <webeteamssdk.api.teams.TeamsAPI.create>`                       |
+|                        |                             | :meth:`get() <webeteamssdk.api.teams.TeamsAPI.get>`                             |
+|                        |                             | :meth:`update() <webeteamssdk.api.teams.TeamsAPI.update>`                       |
+|                        |                             | :meth:`delete() <webeteamssdk.api.teams.TeamsAPI.delete>`                       |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+
+|                        | :ref:`webhooks`             | :meth:`list() <webeteamssdk.api.webhooks.WebhooksAPI.list>`                     |
+|                        |                             | :meth:`create() <webeteamssdk.api.webhooks.WebhooksAPI.create>`                 |
+|                        |                             | :meth:`get() <webeteamssdk.api..WebhooksAPI.get>`                               |
+|                        |                             | :meth:`update() <webeteamssdk.api.webhooks.WebhooksAPI.update>`                 |
+|                        |                             | :meth:`delete() <webeteamssdk.api.webhooks.WebhooksAPI.delete>`                 |
++------------------------+-----------------------------+---------------------------------------------------------------------------------+

--- a/webexteamssdk/api/__init__.py
+++ b/webexteamssdk/api/__init__.py
@@ -45,6 +45,7 @@ from .organizations import OrganizationsAPI
 from .people import PeopleAPI
 from .roles import RolesAPI
 from .rooms import RoomsAPI
+from .room_meeting_details import RoomMeetingDetailsAPI
 from .team_memberships import TeamMembershipsAPI
 from .teams import TeamsAPI
 from .webhooks import WebhooksAPI
@@ -205,6 +206,7 @@ class WebexTeamsAPI(object):
         self.people = PeopleAPI(self._session, object_factory)
         self.roles = RolesAPI(self._session, object_factory)
         self.rooms = RoomsAPI(self._session, object_factory)
+        self.room_meeting_details = RoomMeetingDetailsAPI(self._session, object_factory)
         self.teams = TeamsAPI(self._session, object_factory)
         self.team_memberships = TeamMembershipsAPI(
             self._session, object_factory,

--- a/webexteamssdk/api/room_meeting_details.py
+++ b/webexteamssdk/api/room_meeting_details.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Webex Teams Room Meeting Details API wrapper.
+
+Copyright (c) 2016-2019 Cisco and/or its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
+from builtins import *
+
+from past.builtins import basestring
+
+from ..generator_containers import generator_container
+from ..restsession import RestSession
+from ..utils import (
+    check_type,
+    dict_from_items_with_values,
+)
+
+
+API_ENDPOINT = 'rooms'
+OBJECT_TYPE = 'room_meeting_details'
+
+
+class RoomMeetingDetailsAPI(object):
+    """Webex Teams Room Meeting Details API.
+
+    Wraps the Webex Teams Rooms API and exposes the API as native Python
+    methods that return native Python objects.
+
+    """
+
+    def __init__(self, session, object_factory):
+        """Initialize a new RoomMeetingDetailsAPI object with the provided RestSession.
+
+        Args:
+            session(RestSession): The RESTful session object to be used for
+                API calls to the Webex Teams service.
+
+        Raises:
+            TypeError: If the parameter types are incorrect.
+
+        """
+        check_type(session, RestSession)
+
+        super(RoomMeetingDetailsAPI, self).__init__()
+
+        self._session = session
+        self._object_factory = object_factory
+
+
+    def get(self, roomId):
+        """Get the meeting details of a room, by ID.
+
+        Args:
+            roomId(basestring): The ID of the room to be retrieved.
+
+        Returns:
+            RoomMeetingDetails: A RoomMeetingDetails object with the 
+                meeting details of the requested room.
+
+        Raises:
+            TypeError: If the parameter types are incorrect.
+            ApiError: If the Webex Teams cloud returns an error.
+
+        """
+        check_type(roomId, basestring)
+
+        # API request
+        json_data = self._session.get(API_ENDPOINT + '/' + roomId + '/meetingInfo')
+
+        # Return a room object created from the response JSON data
+        return self._object_factory(OBJECT_TYPE, json_data)

--- a/webexteamssdk/models/immutable.py
+++ b/webexteamssdk/models/immutable.py
@@ -59,7 +59,7 @@ from .mixins.team import TeamBasicPropertiesMixin
 from .mixins.team_membership import TeamMembershipBasicPropertiesMixin
 from .mixins.webhook import WebhookBasicPropertiesMixin
 from .mixins.webhook_event import WebhookEventBasicPropertiesMixin
-
+from .mixins.room_meeting_details import RoomMeetingDetailsBasicPropertiesMixin
 
 class ImmutableData(object):
     """Model a Webex Teams JSON object as an immutable native Python object."""
@@ -239,6 +239,8 @@ class Role(ImmutableData, RoleBasicPropertiesMixin):
 class Room(ImmutableData, RoomBasicPropertiesMixin):
     """Webex Teams Room data model."""
 
+class RoomMeetingDetails(ImmutableData, RoomMeetingDetailsBasicPropertiesMixin):
+    """Webex Teams Room meeting details data model."""
 
 class Team(ImmutableData, TeamBasicPropertiesMixin):
     """Webex Teams Team data model."""
@@ -278,6 +280,7 @@ immutable_data_models = defaultdict(
     person=Person,
     role=Role,
     room=Room,
+    room_meeting_details=RoomMeetingDetails,
     team=Team,
     team_membership=TeamMembership,
     webhook=Webhook,

--- a/webexteamssdk/models/mixins/room_meeting_details.py
+++ b/webexteamssdk/models/mixins/room_meeting_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Community-developed Python SDK for the Webex Teams APIs.
+"""Webex Teams Room meeting details data model.
 
 Copyright (c) 2016-2019 Cisco and/or its affiliates.
 
@@ -30,28 +30,40 @@ from __future__ import (
     unicode_literals,
 )
 
-import logging
+from builtins import *
 
-import webexteamssdk.models.cards as cards
-from ._metadata import (
-    __author__, __author_email__, __copyright__, __description__,
-    __download_url__, __license__, __title__, __url__, __version__,
-)
-from .api import WebexTeamsAPI
-from .exceptions import (
-    AccessTokenError, ApiError, ApiWarning, MalformedResponse, RateLimitError,
-    RateLimitWarning, webexteamssdkException, webexteamssdkWarning,
-)
-from .models.dictionary import dict_data_factory
-from .models.immutable import (
-    AccessToken, AdminAuditEvent, AttachmentAction, Event, GuestIssuerToken,
-    immutable_data_factory, License, Membership, Message, Organization, Person,
-    Role, Room, RoomMeetingDetails, Team, TeamMembership, Webhook, WebhookEvent,
-)
-from .models.simple import simple_data_factory, SimpleDataModel
-from .utils import WebexTeamsDateTime
+from webexteamssdk.utils import WebexTeamsDateTime
 
 
-# Initialize Package Logging
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+class RoomMeetingDetailsBasicPropertiesMixin(object):
+    """Room meeting details basic properties."""
+
+    @property
+    def id(self):
+        """A unique identifier for the room."""
+        return self._json_data.get('id')
+
+    @property
+    def meetingLink(self):
+        """The Webex meeting URL for the room."""
+        return self._json_data.get('meetingLink')
+
+    @property
+    def sipAddress(self):
+        """The SIP address for the room."""
+        return self._json_data.get('sipAddress')
+
+    @property
+    def meetingNumber(self):
+        """The Webex meeting number for the room."""
+        return self._json_data.get('meetingNumber')
+
+    @property
+    def callInTollFreeNumber(self):
+        """The toll-free PSTN number for the room."""
+        return self._json_data.get('callInTollFreeNumber')
+
+    @property
+    def callInTollNumber(self):
+        """The toll (local) PSTN number for the room."""
+        return self._json_data.get('callInTollNumber')


### PR DESCRIPTION
This PR adds a room meeting details endpoint to the webexteamssdk. You can request the meeting details for a room like follows:

```python

from webexteamssdk import WebexTeamsAPI

api = WebexTeamsAPI()

ROOM_ID = "<Add room id here>"

room = api.rooms.get(ROOM_ID)
print(str(room))

meeting_details = api.room_meeting_details.get(ROOM_ID)
print(str(meeting_details))
```

This resolves #111 