### PR TITLE
Add Room Meeting Info API endpoint - Proposed Alternate Implementation

### DIFF
--- a/docs/user/api.rst
+++ b/docs/user/api.rst
@@ -257,6 +257,15 @@ Room
     :inherited-members:
 
 
+.. _RoomMeetingInfo:
+
+Room Meeting Info
+-----------------
+
+.. autoclass:: RoomMeetingInfo()
+    :inherited-members:
+
+
 .. _Team:
 
 Team
@@ -266,7 +275,7 @@ Team
     :inherited-members:
 
 
-.. _Team Membership:
+.. _TeamMembership:
 
 Team Membership
 ---------------

--- a/docs/user/api_structure_table.rst
+++ b/docs/user/api_structure_table.rst
@@ -42,6 +42,7 @@
 |                        | :ref:`rooms`              | :meth:`list() <webeteamssdk.api.rooms.RoomsAPI.list>`                           |
 |                        |                           | :meth:`create() <webeteamssdk.api.rooms.RoomsAPI.create>`                       |
 |                        |                           | :meth:`get() <webeteamssdk.api.rooms.RoomsAPI.get>`                             |
+|                        |                           | :meth:`get_meeting_info() <webeteamssdk.api.rooms.RoomsAPI.get_meeting_info>`   |
 |                        |                           | :meth:`update() <webeteamssdk.api.rooms.RoomsAPI.update>`                       |
 |                        |                           | :meth:`delete() <webeteamssdk.api.rooms.RoomsAPI.delete>`                       |
 +------------------------+---------------------------+---------------------------------------------------------------------------------+

--- a/tests/api/test_rooms.py
+++ b/tests/api/test_rooms.py
@@ -36,6 +36,11 @@ def is_valid_room(obj):
     return isinstance(obj, webexteamssdk.Room) and obj.id is not None
 
 
+def is_valid_room_meeting_info(obj):
+    return (isinstance(obj, webexteamssdk.RoomMeetingInfo)
+            and obj.roomId is not None)
+
+
 def are_valid_rooms(iterable):
     return all([is_valid_room(obj) for obj in iterable])
 
@@ -154,6 +159,11 @@ def test_create_team_room(team_room):
 def test_get_room_details(api, group_room):
     room = api.rooms.get(group_room.id)
     assert is_valid_room(room)
+
+
+def test_get_room_meeting_info(api, group_room):
+    room_meeting_info = api.rooms.get_meeting_info(group_room.id)
+    assert is_valid_room_meeting_info(room_meeting_info)
 
 
 def test_update_room_title(api, group_room):

--- a/webexteamssdk/api/rooms.py
+++ b/webexteamssdk/api/rooms.py
@@ -189,6 +189,32 @@ class RoomsAPI(object):
         # Return a room object created from the response JSON data
         return self._object_factory(OBJECT_TYPE, json_data)
 
+    def get_meeting_info(self, roomId):
+        """Get the meeting details for a room.
+
+        Args:
+            roomId(basestring): The unique identifier for the room.
+
+        Returns:
+            RoomMeetingInfo: A Room Meeting Info object with the meeting
+            details for the room such as the SIP address, meeting URL,
+            toll-free and toll dial-in numbers.
+
+        Raises:
+            TypeError: If the parameter types are incorrect.
+            ApiError: If the Webex Teams cloud returns an error.
+
+        """
+        check_type(roomId, basestring)
+
+        # API request
+        json_data = self._session.get(
+            API_ENDPOINT + '/' + roomId + '/meetingInfo',
+        )
+
+        # Return a room meeting info object created from the response JSON data
+        return self._object_factory("room_meeting_info", json_data)
+
     def update(self, roomId, title, **request_parameters):
         """Update details for a room, by ID.
 

--- a/webexteamssdk/api/rooms.py
+++ b/webexteamssdk/api/rooms.py
@@ -73,7 +73,7 @@ class RoomsAPI(object):
         self._object_factory = object_factory
 
     @generator_container
-    def list(self, teamId=None, type=None, sortBy=None, max=None,
+    def list(self, teamId=None, type=None, sortBy=None, max=100,
              **request_parameters):
         """List rooms.
 
@@ -189,7 +189,7 @@ class RoomsAPI(object):
         # Return a room object created from the response JSON data
         return self._object_factory(OBJECT_TYPE, json_data)
 
-    def update(self, roomId, title=None, **request_parameters):
+    def update(self, roomId, title, **request_parameters):
         """Update details for a room, by ID.
 
         Args:
@@ -207,7 +207,7 @@ class RoomsAPI(object):
 
         """
         check_type(roomId, basestring)
-        check_type(roomId, basestring, optional=True)
+        check_type(roomId, basestring)
 
         put_data = dict_from_items_with_values(
             request_parameters,

--- a/webexteamssdk/models/immutable.py
+++ b/webexteamssdk/models/immutable.py
@@ -55,6 +55,7 @@ from .mixins.organization import OrganizationBasicPropertiesMixin
 from .mixins.person import PersonBasicPropertiesMixin
 from .mixins.role import RoleBasicPropertiesMixin
 from .mixins.room import RoomBasicPropertiesMixin
+from .mixins.room_meeting_info import RoomMeetingInfoBasicPropertiesMixin
 from .mixins.team import TeamBasicPropertiesMixin
 from .mixins.team_membership import TeamMembershipBasicPropertiesMixin
 from .mixins.webhook import WebhookBasicPropertiesMixin
@@ -240,6 +241,10 @@ class Room(ImmutableData, RoomBasicPropertiesMixin):
     """Webex Teams Room data model."""
 
 
+class RoomMeetingInfo(ImmutableData, RoomMeetingInfoBasicPropertiesMixin):
+    """Webex Teams Room Meeting Info data model."""
+
+
 class Team(ImmutableData, TeamBasicPropertiesMixin):
     """Webex Teams Team data model."""
 
@@ -278,6 +283,7 @@ immutable_data_models = defaultdict(
     person=Person,
     role=Role,
     room=Room,
+    room_meeting_info=RoomMeetingInfo,
     team=Team,
     team_membership=TeamMembership,
     webhook=Webhook,

--- a/webexteamssdk/models/mixins/room.py
+++ b/webexteamssdk/models/mixins/room.py
@@ -41,12 +41,12 @@ class RoomBasicPropertiesMixin(object):
     @property
     def id(self):
         """A unique identifier for the room."""
-        return self._json_data.get('id')
+        return self._json_data.get("id")
 
     @property
     def title(self):
         """A user-friendly name for the room."""
-        return self._json_data.get('title')
+        return self._json_data.get("title")
 
     @property
     def type(self):
@@ -57,22 +57,22 @@ class RoomBasicPropertiesMixin(object):
 
             `group`: Group room
         """
-        return self._json_data.get('type')
+        return self._json_data.get("type")
 
     @property
     def isLocked(self):
         """Whether the room is moderated (locked) or not."""
-        return self._json_data.get('isLocked')
+        return self._json_data.get("isLocked")
 
     @property
     def teamId(self):
         """The ID for the team with which this room is associated."""
-        return self._json_data.get('teamId')
+        return self._json_data.get("teamId")
 
     @property
     def lastActivity(self):
-        """The date and time of the room's last activity."""
-        last_activity = self._json_data.get('lastActivity')
+        """The date and time of the room"s last activity."""
+        last_activity = self._json_data.get("lastActivity")
         if last_activity:
             return WebexTeamsDateTime.strptime(last_activity)
         else:
@@ -81,18 +81,18 @@ class RoomBasicPropertiesMixin(object):
     @property
     def creatorId(self):
         """The ID of the person who created this room."""
-        return self._json_data.get('creatorId')
-
-    @property
-    def ownerId(self):
-        """The ID of the organization which owns this room."""
-        return self._json_data.get('ownerId')
+        return self._json_data.get("creatorId")
 
     @property
     def created(self):
         """The date and time the room was created."""
-        created = self._json_data.get('created')
+        created = self._json_data.get("created")
         if created:
             return WebexTeamsDateTime.strptime(created)
         else:
             return None
+
+    @property
+    def ownerId(self):
+        """The ID of the organization which owns this room."""
+        return self._json_data.get("ownerId")

--- a/webexteamssdk/models/mixins/room_meeting_info.py
+++ b/webexteamssdk/models/mixins/room_meeting_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Community-developed Python SDK for the Webex Teams APIs.
+"""Webex Teams Room Meeting Info data model.
 
 Copyright (c) 2016-2019 Cisco and/or its affiliates.
 
@@ -30,28 +30,38 @@ from __future__ import (
     unicode_literals,
 )
 
-import logging
-
-import webexteamssdk.models.cards as cards
-from ._metadata import (
-    __author__, __author_email__, __copyright__, __description__,
-    __download_url__, __license__, __title__, __url__, __version__,
-)
-from .api import WebexTeamsAPI
-from .exceptions import (
-    AccessTokenError, ApiError, ApiWarning, MalformedResponse, RateLimitError,
-    RateLimitWarning, webexteamssdkException, webexteamssdkWarning,
-)
-from .models.dictionary import dict_data_factory
-from .models.immutable import (
-    AccessToken, AdminAuditEvent, AttachmentAction, Event, GuestIssuerToken,
-    immutable_data_factory, License, Membership, Message, Organization, Person,
-    Role, Room, RoomMeetingInfo, Team, TeamMembership, Webhook, WebhookEvent,
-)
-from .models.simple import simple_data_factory, SimpleDataModel
-from .utils import WebexTeamsDateTime
+from builtins import *
 
 
-# Initialize Package Logging
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+class RoomMeetingInfoBasicPropertiesMixin(object):
+    """Room basic properties."""
+
+    @property
+    def roomId(self):
+        """A unique identifier for the room."""
+        return self._json_data.get("roomId")
+
+    @property
+    def meetingLink(self):
+        """The Webex meeting URL for the room."""
+        return self._json_data.get("meetingLink")
+
+    @property
+    def sipAddress(self):
+        """The SIP address for the room."""
+        return self._json_data.get("sipAddress")
+
+    @property
+    def meetingNumber(self):
+        """The Webex meeting number for the room."""
+        return self._json_data.get("meetingNumber")
+
+    @property
+    def callInTollFreeNumber(self):
+        """The toll-free PSTN number for the room."""
+        return self._json_data.get("callInTollFreeNumber")
+
+    @property
+    def callInTollNumber(self):
+        """The toll (local) PSTN number for the room."""
+        return self._json_data.get("callInTollNumber")


### PR DESCRIPTION
@sQu4rks, this is a proposed alternate implementation to PR #129 to resolve issue #100 

In this version of the codebase, I prefer to keep all of the endpoints associated with an API (like the Rooms API) in the same module and hierarchically organized under the same API group under the `WebexTeamsAPI` top-level connection object.

Use of this endpoint under this proposal looks like this:

```python
room_meeting_info = api.rooms.get_meeting_info(room.id)
```
