### PR TITLE
Fix for #147

### DIFF
--- a/webexteamssdk/restsession.py
+++ b/webexteamssdk/restsession.py
@@ -150,6 +150,8 @@ def user_agent(be_geo_id=None, caller=None):
     if platform.machine():
         data["cpu"] = platform.machine()
 
+    data["organization"] = {}
+    
     # Add self-identified organization information to the User-Agent Header.
     if be_geo_id:
         data["organization"]["be_geo_id"] = be_geo_id


### PR DESCRIPTION
`data["organization"]` is never initialised so it is not possible to use the `be_geo_id` or `caller` features.

Trying to set an attribute in the user agent, but I get a key error.


```python
        self.teams = WebexTeamsAPI(access_token=access_token,
                                   be_geo_id= f"{str(uuid.uuid4())}".upper())
```

```bash
  File "/Users/fibrady/projects/core/venv/lib/python3.9/site-packages/webexteamssdk/api/__init__.py", line 182, in __init__
    self._session = RestSession(
  File "/Users/fibrady/projects/core/venv/lib/python3.9/site-packages/webexteamssdk/restsession.py", line 230, in __init__
    "User-Agent": user_agent(be_geo_id=be_geo_id, caller=caller),
  File "/Users/fibrady/projects/core/venv/lib/python3.9/site-packages/webexteamssdk/restsession.py", line 155, in user_agent
    data["organization"]["be_geo_id"] = be_geo_id
KeyError: 'organization'
```