### PR TITLE
Bug fix regarding pagination

### DIFF
--- a/webexteamssdk/restsession.py
+++ b/webexteamssdk/restsession.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 
 # Helper Functions
-def _fix_next_url(next_url):
+def _fix_next_url(next_url, params):
     """Remove max=null parameter from URL.
 
     Patch for Webex Teams Defect: "next" URL returned in the Link headers of
@@ -96,6 +96,10 @@ def _fix_next_url(next_url):
             query_list.remove("max=null")
             warnings.warn("`max=null` still present in next-URL returned "
                           "from Webex Teams", RuntimeWarning)
+        if params:
+            for k, v in params.items():
+                if not any(p.startswith('{}='.format(k)) for p in query_list):
+                    query_list.append('{}={}'.format(k, v))
         new_query = "&".join(query_list)
         parsed_url = list(parsed_url)
         parsed_url[4] = new_query
@@ -151,7 +155,7 @@ def user_agent(be_geo_id=None, caller=None):
         data["cpu"] = platform.machine()
 
     data["organization"] = {}
-    
+
     # Add self-identified organization information to the User-Agent Header.
     if be_geo_id:
         data["organization"]["be_geo_id"] = be_geo_id
@@ -230,7 +234,6 @@ class RestSession(object):
         # Disable ssl cert verification if chosen by user
         if disable_ssl_verify:
             self._req_session.verify = False
-
 
         if proxies is not None:
             self._req_session.proxies.update(proxies)
@@ -424,11 +427,13 @@ class RestSession(object):
             if response.links.get("next"):
                 next_url = response.links.get("next").get("url")
 
-                # Patch for Webex Teams "max=null" in next URL bug.
+                # Patch for Webex Teams "max=null" in next URL bug + missing
+                # params, like mentionedPeople, which can be mandatory for
+                # bots
                 # Testing shows that patch is no longer needed; raising a
                 # warnning if it is still taking effect;
                 # considering for future removal
-                next_url = _fix_next_url(next_url)
+                next_url = _fix_next_url(next_url, params)
 
                 # Subsequent requests
                 response = self.request("GET", next_url, erc, **kwargs)


### PR DESCRIPTION
https://github.com/CiscoDevNet/webexteamssdk/issues/168

The Webex Teams api does not return all parameters when returning the next url link header. Consequently,
the object listing can be broken or worse, can succeed without returning objects expected by the provided filter.

Example: a bot needs to specify mentionedPeople=me to be allowed to list room messages. If there are several pages to be returned
then the listing will fail because the mentionedPeople query parameter won't be specified when fetching the next pages

Signed-off-by: xXraphXx <xXraphXx@users.noreply.github.com>